### PR TITLE
feat: add git alias completions and disable gcloud in starship

### DIFF
--- a/git/completion.zsh
+++ b/git/completion.zsh
@@ -8,6 +8,21 @@ then
   source $completion
 fi
 
+# Complete git aliases like their underlying commands
+# compdef <alias>=git makes the alias complete as `git <subcommand>`
+compdef g=git
+compdef _git gco=git-checkout
+compdef _git gb=git-branch
+compdef _git gc=git-commit
+compdef _git gca=git-commit
+compdef _git ga=git-add
+compdef _git gd=git-diff
+compdef _git gl=git-pull
+compdef _git gp=git-push
+compdef _git gs=git-status
+compdef _git glog=git-log
+compdef _git gac=git-commit
+
 # GitHub CLI completion
 if (( $+commands[gh] )); then
   eval "$(gh completion -s zsh)"

--- a/starship/starship.toml.symlink
+++ b/starship/starship.toml.symlink
@@ -1,3 +1,6 @@
 # Starship prompt configuration
 # See https://starship.rs/config/ for all options
 # Using defaults — delete or modify sections to customize
+
+[gcloud]
+disabled = true


### PR DESCRIPTION
## Summary
- Add zsh `compdef` entries for git shell aliases (`g`, `gco`, `gb`, `gc`, `ga`, `gd`, `gl`, `gp`, `gs`, `glog`, `gca`, `gac`) so tab completion works for branches, files, and flags
- Disable the `gcloud` module in Starship to declutter the prompt

## Test plan
- [ ] Open a new shell and verify `gco <tab>` completes branch names
- [ ] Verify `g <tab>` completes git subcommands
- [ ] Verify the gcloud section no longer appears in the Starship prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)