### PR TITLE
docs: add Refresh section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,24 @@ Everything is configured and tweaked within `~/.dotfiles`.
 The main file you may want to change right off the bat is `zsh/zshrc.symlink`,
 which sets up a few paths that'll be different on your particular machine. However, if you are just looking to add paths or other setup to things outside these dotfiles, create a `.localrc` file in your home directory and this will automatically pick it up.
 
-`dot` is a simple script that installs some dependencies, sets sane macOS
-defaults, and so on. Tweak this script, and occasionally run `dot` from
-time to time to keep your environment fresh and up-to-date. You can find
-this script in `bin/`.
+## Refresh
+
+### Quick refresh
+
+`dot` is a simple script that installs some dependencies, sets sane macOS defaults, and so on. Run `dot` from time to time to keep your environment fresh and up-to-date. You can find this script in `bin/`.
+
+### Full refresh
+
+To pull the latest changes from the repo and fully refresh your environment:
+
+```sh
+cd ~/.dotfiles
+git pull
+dot
+reload!
+```
+
+For a completely clean slate, restart your terminal after running these commands.
 
 ## What's Included
 


### PR DESCRIPTION
## Summary
- Add a new **Refresh** section to the README between Install and What's Included
- Move the `dot` script description from Install into a **Quick refresh** subsection
- Add a **Full refresh** subsection with steps: `git pull` > `dot` > `reload!`

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm no duplicate `dot` references remain in Install

🤖 Generated with [Claude Code](https://claude.com/claude-code)