### PR TITLE
chore: add .claude/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 git/gitconfig.local.symlink
 Brewfile.lock.json
+.claude/


### PR DESCRIPTION
## Summary
- Add `.claude/` to `.gitignore` to keep Claude Code local config out of the repo

## Test plan
- [ ] Verify `.claude/` no longer shows as untracked in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)