### PR TITLE
feat: switch yarn to Corepack; fix `e` in fresh shells

### DIFF
--- a/bin/dot
+++ b/bin/dot
@@ -27,7 +27,7 @@ while test $# -gt 0; do
 			displayUsageAndExit
 			;;
 		"-e"|"--edit")
-			exec "$EDITOR" "$dotfilesDirectory"
+			exec $EDITOR "$dotfilesDirectory"
 			exit
 			;;
 		*)

--- a/bin/e
+++ b/bin/e
@@ -13,4 +13,4 @@
 #   $ e .
 #   $ e /usr/local
 #   # => opens the specified directory in your editor
-exec "$EDITOR" "${1:-.}"
+exec $EDITOR "${1:-.}"

--- a/editors/env.zsh
+++ b/editors/env.zsh
@@ -1,4 +1,4 @@
-if (( $+commands[antigravity] )); then
+if [[ -x "$HOME/.antigravity/antigravity/bin/antigravity" ]]; then
   export EDITOR='antigravity'
 elif (( $+commands[code] )); then
   export EDITOR='code --wait'

--- a/yarn/install.sh
+++ b/yarn/install.sh
@@ -1,12 +1,18 @@
 #!/bin/sh
 
-if ! [[ -n "$(asdf plugin list | grep yarn)" ]]; then
-  echo "Installing yarn plugin..."
-  asdf plugin add yarn
-else
-  echo "Updating yarn plugin..."
-  asdf plugin update yarn
+# Yarn is managed by Corepack (bundled with Node.js), not asdf.
+# Projects declare their yarn version via "packageManager" in package.json.
+
+# Remove legacy asdf yarn plugin if still present
+if [[ -n "$(asdf plugin list 2>/dev/null | grep yarn)" ]]; then
+  echo "Removing asdf yarn plugin (yarn is now managed by Corepack)..."
+  asdf plugin remove yarn
 fi
 
-asdf install yarn latest &&
-asdf set -u yarn latest
+# Ensure Corepack is enabled for the current Node.js
+if command -v corepack &> /dev/null; then
+  corepack enable
+  echo "Corepack enabled — yarn will be resolved per-project via packageManager field."
+else
+  echo "Warning: corepack not found. Install Node.js 16.9+ to get Corepack."
+fi


### PR DESCRIPTION
## Summary

- Switch yarn management from the asdf plugin to Corepack (`18c300e`).
- Fix `e` (and `dot -e`) failing in fresh iTerm windows when Antigravity is installed (`187eb26`).

### Editor fix — root cause

In a fresh shell, `e .` errored with:

```
/Users/eddie/.dotfiles/bin/e: line 16: exec: code --wait: not found
```

Two bugs combined:

1. `editors/env.zsh` probed `$+commands[antigravity]`, but `zsh/zshrc.symlink` deliberately sources `path.zsh` files *after* `env.zsh` files. On first shell startup antigravity was not yet on `PATH`, so `EDITOR` fell through to `code --wait`. After `reload!`, antigravity persisted in `PATH` from the prior session and the check succeeded — which is why a hard reload "fixed" it.
2. `bin/e` and `bin/dot` quoted `"$EDITOR"`, so `exec` searched for a binary literally named `code --wait` (space and all) and failed.

Fix: detect antigravity by filesystem path so the check no longer depends on `PATH` ordering, and unquote `$EDITOR` in `bin/e` / `bin/dot` so command-plus-flag values dispatch correctly.

## Test plan

- [x] Open a fresh iTerm window, run `echo "$EDITOR"` → expect `antigravity`.
- [x] In the same fresh window, `e .` opens Antigravity without `exec: ... not found`.
- [ ] On a machine without antigravity installed, `EDITOR` falls through to `code --wait` and `e .` opens VS Code.
- [ ] `dot -e` still opens the dotfiles directory.
- [ ] Corepack-managed yarn: `yarn --version` resolves via Corepack, no asdf shim involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)