### PR TITLE
fix: repoint editor + grc paths after upstream renames

### DIFF
--- a/editors/env.zsh
+++ b/editors/env.zsh
@@ -1,5 +1,5 @@
-if [[ -x "$HOME/.antigravity/antigravity/bin/antigravity" ]]; then
-  export EDITOR='antigravity'
+if [[ -x "$HOME/.antigravity-ide/antigravity-ide/bin/antigravity-ide" ]]; then
+  export EDITOR='antigravity-ide'
 elif (( $+commands[code] )); then
   export EDITOR='code --wait'
 else

--- a/editors/path.zsh
+++ b/editors/path.zsh
@@ -1,2 +1,2 @@
 export PATH="$HOME/.codeium/windsurf/bin:$PATH"
-export PATH="$HOME/.antigravity/antigravity/bin:$PATH"
+export PATH="$HOME/.antigravity-ide/antigravity-ide/bin:$PATH"

--- a/system/grc.zsh
+++ b/system/grc.zsh
@@ -1,5 +1,5 @@
 # GRC colorizes nifty unix tools all over the place
 if (( $+commands[grc] )) && (( $+commands[brew] ))
 then
-  source `brew --prefix`/etc/grc.bashrc
+  source "$(brew --prefix)/etc/grc.zsh"
 fi


### PR DESCRIPTION
## Summary
- Repoint `editors/env.zsh` and `editors/path.zsh` at the renamed Antigravity IDE install (`~/.antigravity-ide/antigravity-ide/bin/antigravity-ide`). The old `~/.antigravity/...` symlink is dangling after the upgrade, so the `-x` probe failed and `$EDITOR` fell through to `code --wait`, causing `e some/path` to open VSCode.
- Source `grc.zsh` instead of the no-longer-shipped `grc.bashrc`. Homebrew's `grc` formula now ships `grc.sh`/`grc.zsh`/`grc.fish`/`grc.conf` only, so the old `source` line produced a startup error on every shell launch.

Both are post-upstream-rename config-drift fixes; no behavior change beyond restoring the intended editor and silencing the grc startup error.

The filesystem `-x` probe (not `$+commands[...]`) is preserved on purpose — `zsh/zshrc.symlink` sources `*/env.zsh` before `*/path.zsh`, so PATH isn't yet built when the check runs.

## Test plan
- [x] Fresh `zsh -i -c 'echo $EDITOR'` → `antigravity-ide`
- [x] `command -v antigravity-ide` → `/Users/.../antigravity-ide/bin/antigravity-ide`
- [x] Fresh shell startup no longer prints the `grc.bashrc: no such file or directory` error
- [ ] `e .` from any directory opens Antigravity IDE (GUI check — confirmed manually)
- [ ] `dot -e` opens dotfiles in Antigravity IDE (same `$EDITOR` path; should follow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)